### PR TITLE
Setup initial Dispatch Workflow for Ansible Playbooks

### DIFF
--- a/.github/workflows/ansible-playbooks.yml
+++ b/.github/workflows/ansible-playbooks.yml
@@ -1,0 +1,39 @@
+name: Run Ansible playbooks
+
+on:
+  workflow_dispatch:
+    inputs:
+      USER:
+        description: 'User to run in playbook'
+        type: string
+        required: true
+      TAGS:
+        description: 'Tags to run'
+        type: string
+        required: true
+
+jobs:
+  deploy:
+    name: Deploy Ansible Playbook
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up SSH
+        run: |
+          echo "${{ secrets.SSH_KEY }}" > private_key.pem
+          chmod 600 private_key.pem
+          
+      - name: Install Ansible
+        shell: bash
+        run: |
+          sudo apt update
+          sudo apt install -y ansible
+
+      - name: Run Ansible Playbook
+        env:
+          ANSIBLE_USER: ${{ inputs.USER }}
+          ANSIBLE_HOST_KEY_CHECKING: False
+        run: |
+          ansible-playbook -i inventory/inventory playbooks/playbook.yml --private-key private_key.pem -u ${{ secrets.ANSIBLE_USER }} --tags="{{ inputs.tags }}"


### PR DESCRIPTION
### Initial Git Action setup

- Dispatch Workflow needs to exist on the main branch for testing the Dispatch trigger call.
- Setup secrets for ANSIBLE_USER and SSH_KEY
-  Built the playbooks call based off options given in the dispatch call.